### PR TITLE
clarifies default backoff numbers

### DIFF
--- a/packages/fetch-retry/readme.md
+++ b/packages/fetch-retry/readme.md
@@ -35,7 +35,7 @@ Some errors are very common in production (like the underlying `Socket`
 yielding `ECONNRESET`), and can easily and instantly be remediated
 by retrying.
 
-The default behavior of `fetch-retry` is to attempt retries **10**, **60**
+The default behavior of `fetch-retry` is to attempt retries **10**, **60**,
 **360**, **2160** and **12960** milliseconds (a total of 5 retries) after
 a _network error_, _429_ or _5xx_ error occur.
 


### PR DESCRIPTION
Had to read this a couple of times before I understood what it said:

![image](https://github.com/solsson/vercel-fetch/assets/144945/32c434f1-c54c-44f0-bf5a-b584a130fa7a)
